### PR TITLE
feat: release candidate changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       formula:
         description: 'Formula to release Homebrew'
-        default: twilio
+        default: twilio@rc
       version:
         description: 'Release version - Same as CLI version'
         required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       formula:
         description: 'Formula to release Homebrew'
-        default: twilio@rc
+        default: twilio
       version:
         description: 'Release version - Same as CLI version'
         required: true

--- a/Formula/twilio@rc.rb
+++ b/Formula/twilio@rc.rb
@@ -1,0 +1,21 @@
+require "language/node"
+
+class TwilioATrc < Formula
+  desc "unleash the power of Twilio from your command prompt"
+  homepage "https://github.com/twilio/twilio-cli"
+  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v2.27.0-rc.1/twilio-v2.27.0-rc.1.tar.gz"
+  version "2.27.0-rc.1"
+  sha256 "919ff4d3df952e61506f967dc63d0ad007a30a0ac0e78b22747a3aa93fd02139"
+  depends_on "node"
+
+  def install
+    inreplace "bin/twilio", /^CLIENT_HOME=/, "export TWILIO_OCLIF_CLIENT_HOME=#{lib/"client"}\nCLIENT_HOME="
+    libexec.install Dir["*"]
+    bin.install_symlink libexec/"bin/twilio"
+  end
+
+  def post_install
+    pid = spawn("node #{libexec}/welcome.js")
+    Process.wait pid
+  end
+end


### PR DESCRIPTION
For [DII-190](https://issues.corp.twilio.com/browse/DII-190)

Changes overview:

Based on the [suggestion in the brew forum](https://github.com/Homebrew/discussions/discussions/2363), I've created a new formula (twilio@rc). This formula will be used for release candidates. Brew install by default would still use [twilio.rb ](https://github.com/twilio/homebrew-brew/blob/main/Formula/twilio.rb)(formula name) and the URL in this would point to the latest release. twilio@rc.rb would have the URL to the release candidate and the release candidate can be downloaded by mentioning the version as part of the command. 

Formula for the latest package

![Screenshot 2021-11-02 at 12 58 46 PM](https://user-images.githubusercontent.com/87780745/139804196-25d7c6ad-c41f-47f6-a601-42859874acac.png)

Formula for the rc package
![image](https://user-images.githubusercontent.com/87780745/139804155-02a60281-564c-42a8-bd7b-a993bcc9001d.png)

Release parameter:
![Screenshot 2021-11-02 at 1 04 26 PM](https://user-images.githubusercontent.com/87780745/139804673-51c534e7-8716-481d-ab63-399faf6ec891.png)



``
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
