### PR TITLE
fix: update urls to remove dependency on aws s3

### DIFF
--- a/.github/scripts/update-formula.sh
+++ b/.github/scripts/update-formula.sh
@@ -14,7 +14,8 @@ if [ "$version" != "$current_version" ]; then
   sed -i.bak "s/^class [^ ]*/class $class_name/" Formula/$formula@$current_version.rb
 fi
 formula_path="Formula/$formula.rb"
-sed -E -i.bak "s/twilio-v$version_pattern/twilio-v$version/g" "$formula_path"
+sed -E -i.bak "s/$version_pattern/$version/g" "$formula_path"
+sed -E -i.bak "s/twilio-$version_pattern/twilio-$version/g" "$formula_path"
 sed -i.bak "s/version .*/version \"$version\"/" "$formula_path"
 sed -i.bak "s/sha256 .*/sha256 \"$sha\"/" "$formula_path"
 echo "Git configurations"

--- a/Formula/twilio.rb
+++ b/Formula/twilio.rb
@@ -3,7 +3,7 @@ require "language/node"
 class Twilio < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v5.1.0/twilio-v5.1.0.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/5.1.0/twilio-5.1.0.tar.gz"
   version "5.1.0"
   sha256 "6e6ae7f37471b0a17fc30b079e1d757551aafe41eeeb19dc51f9b59135ba51e2"
   depends_on "node"

--- a/Formula/twilio@2.36.1.rb
+++ b/Formula/twilio@2.36.1.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT2361 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v2.36.1/twilio-v2.36.1.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/2.36.1/twilio-2.36.1.tar.gz"
   version "2.36.1"
   sha256 "9c57ba33583ebf7c3c2ca20100554a9c2050c6a707a51bdae71fac18e64c0e21"
   depends_on "node"

--- a/Formula/twilio@3.0.0.rb
+++ b/Formula/twilio@3.0.0.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT300 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v3.0.0/twilio-v3.0.0.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.0.0/twilio-3.0.0.tar.gz"
   version "3.0.0"
   sha256 "8789f1d314ed4bd7c7081d4424fba24fdaa897850d8691a3c78fb8ebc10f5893"
   depends_on "node"

--- a/Formula/twilio@3.0.1.rb
+++ b/Formula/twilio@3.0.1.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT301 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v3.0.1/twilio-v3.0.1.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.0.1/twilio-3.0.1.tar.gz"
   version "3.0.1"
   sha256 "6164f1a6d0337e996e7208fe3c81f6361bda4af9093dbb528435ce538e5341bb"
   depends_on "node"

--- a/Formula/twilio@3.1.0.rb
+++ b/Formula/twilio@3.1.0.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT310 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v3.1.0/twilio-v3.1.0.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.1.0/twilio-3.1.0.tar.gz"
   version "3.1.0"
   sha256 "00c0de94f947bcff2f69f3517b0019eab66ffc87583738de22413b7bfa68940a"
   depends_on "node"

--- a/Formula/twilio@3.2.0.rb
+++ b/Formula/twilio@3.2.0.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT320 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v3.2.0/twilio-v3.2.0.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.2.0/twilio-3.2.0.tar.gz"
   version "3.2.0"
   sha256 "0f4683b0b37dee914c4ff808062831600f6a17d9f285e02464d1fa518fb5b60a"
   depends_on "node"

--- a/Formula/twilio@3.2.1.rb
+++ b/Formula/twilio@3.2.1.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT321 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v3.2.1/twilio-v3.2.1.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.2.1/twilio-3.2.1.tar.gz"
   version "3.2.1"
   sha256 "25645c3cdc5c77122aba79bc1db784defd019a26dba484a4badaf9aad69cc04b"
   depends_on "node"

--- a/Formula/twilio@3.3.0.rb
+++ b/Formula/twilio@3.3.0.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT330 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v3.3.0/twilio-v3.3.0.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.3.0/twilio-3.3.0.tar.gz"
   version "3.3.0"
   sha256 "a75bd698b80a8eabdcdc8f511abb0e77b91ce1b025f82de4d741eaa25203f48d"
   depends_on "node"

--- a/Formula/twilio@3.3.1.rb
+++ b/Formula/twilio@3.3.1.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT331 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v3.3.1/twilio-v3.3.1.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.3.1/twilio-3.3.1.tar.gz"
   version "3.3.1"
   sha256 "c9cc4067e2fb20b876aa559e540489912b3d3e17b4d9ae9c28c8d315ee6374b3"
   depends_on "node"

--- a/Formula/twilio@3.3.2.rb
+++ b/Formula/twilio@3.3.2.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT332 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v3.3.2/twilio-v3.3.2.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.3.2/twilio-3.3.2.tar.gz"
   version "3.3.2"
   sha256 "8e7a5080377cefbf1948a752fc83b6cdb2568400aad994620e183a981e8f26ba"
   depends_on "node"

--- a/Formula/twilio@3.4.0.rb
+++ b/Formula/twilio@3.4.0.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT340 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v3.4.0/twilio-v3.4.0.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.4.0/twilio-3.4.0.tar.gz"
   version "3.4.0"
   sha256 "b5f7ef76820a41706e4d499b6e1d17f8abf3a3326ac957f055841c946a3ec788"
   depends_on "node"

--- a/Formula/twilio@3.4.1.rb
+++ b/Formula/twilio@3.4.1.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT341 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v3.4.1/twilio-v3.4.1.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.4.1/twilio-3.4.1.tar.gz"
   version "3.4.1"
   sha256 "04353a522f83f2c3433860c6442bf12310b1fdc1027de0732d8090f15809c5f9"
   depends_on "node"

--- a/Formula/twilio@3.4.2.rb
+++ b/Formula/twilio@3.4.2.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT342 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v3.4.2/twilio-v3.4.2.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.4.2/twilio-3.4.2.tar.gz"
   version "3.4.2"
   sha256 "0f2d3448baee770e091b7c20725d05dd1ecdb48ad435ffc2d7c778b58f8c7c76"
   depends_on "node"

--- a/Formula/twilio@3.5.0.rb
+++ b/Formula/twilio@3.5.0.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT350 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v3.5.0/twilio-v3.5.0.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.5.0/twilio-3.5.0.tar.gz"
   version "3.5.0"
   sha256 "b1cd2ce96cc617ef05c107e554d8de5ecaddda10bd7313fc34635b51a771ae9c"
   depends_on "node"

--- a/Formula/twilio@3.6.0.rb
+++ b/Formula/twilio@3.6.0.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT360 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v3.6.0/twilio-v3.6.0.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.6.0/twilio-3.6.0.tar.gz"
   version "3.6.0"
   sha256 "c425ff481e4a180631b931dcd124d555c358a4b6703c6fd2e1275ee415d0f814"
   depends_on "node"

--- a/Formula/twilio@4.0.1.rb
+++ b/Formula/twilio@4.0.1.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT401 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v4.0.1/twilio-v4.0.1.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/4.0.1/twilio-4.0.1.tar.gz"
   version "4.0.1"
   sha256 "9da72869c7401c5b3eb80a18e95759533300d8915f522d049037c52ae1b2edab"
   depends_on "node"

--- a/Formula/twilio@4.1.0.rb
+++ b/Formula/twilio@4.1.0.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT410 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v4.1.0/twilio-v4.1.0.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/4.1.0/twilio-4.1.0.tar.gz"
   version "4.1.0"
   sha256 "eb60b97df041dd19292f39a5daf32769bac0231b95f31d4277605dc9060c14c9"
   depends_on "node"

--- a/Formula/twilio@4.2.0.rb
+++ b/Formula/twilio@4.2.0.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT420 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v4.2.0/twilio-v4.2.0.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/4.2.0/twilio-4.2.0.tar.gz"
   version "4.2.0"
   sha256 "6c4d28730c689034500a0f52214fff41dccd6e2ffa7ecd702799bdd2615a9d2a"
   depends_on "node"

--- a/Formula/twilio@5.0.0.rb
+++ b/Formula/twilio@5.0.0.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwilioAT500 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v5.0.0/twilio-v5.0.0.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/5.0.0/twilio-5.0.0.tar.gz"
   version "5.0.0"
   sha256 "582e8425d459506a6b16b81410db1efbe7399d276199277961135fa35ef0a1b9"
   depends_on "node"

--- a/Formula/twiliodraft.rb
+++ b/Formula/twiliodraft.rb
@@ -3,7 +3,7 @@ require "language/node"
 class Twiliodraft < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-stage.s3.amazonaws.com/channels/draft/twilio-v3.1.0-draft.3/twilio-v3.1.0-draft.3.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.1.0-draft.3/twilio-3.1.0-draft.3.tar.gz"
   version "3.1.0-draft.3"
   sha256 "8a43bb3b8a93e0c221d971be30ad96e4ffb38d85bcb1d006671aa57992761e4f"
   depends_on "node"

--- a/Formula/twiliodraft@2.35.0-draft.1.rb
+++ b/Formula/twiliodraft@2.35.0-draft.1.rb
@@ -3,9 +3,9 @@ require "language/node"
 class TwiliodraftAT2350Draft1 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/channels/draft/twilio-v2.35.0-draft.1/twilio-v2.35.0-draft.1.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/2.35.0-draft.1/twilio-2.35.0-draft.1.tar.gz"
   version "2.35.0-draft.1"
-  sha256 "bb8252cca1cce30051da332fc46141938c6339b14d9e1d3164669a68854e72d3"
+  sha256 "0188f76a777db87fea4cb35868cdbfbbe5b8e84bd3ca04b13db46fb353342df4"
   depends_on "node"
 
   def install

--- a/Formula/twiliodraft@3.1.0-draft.2.rb
+++ b/Formula/twiliodraft@3.1.0-draft.2.rb
@@ -3,7 +3,7 @@ require "language/node"
 class TwiliodraftAT310Draft2 < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/channels/draft/twilio-v3.1.0-draft.2/twilio-v3.1.0-draft.2.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/3.1.0-draft.2/twilio-3.1.0-draft.2.tar.gz"
   version "3.1.0-draft.2"
   sha256 "8a43bb3b8a93e0c221d971be30ad96e4ffb38d85bcb1d006671aa57992761e4f"
   depends_on "node"

--- a/Formula/twiliorc.rb
+++ b/Formula/twiliorc.rb
@@ -3,7 +3,7 @@ require "language/node"
 class Twiliorc < Formula
   desc "unleash the power of Twilio from your command prompt"
   homepage "https://github.com/twilio/twilio-cli"
-  url "https://twilio-cli-prod.s3.amazonaws.com/channels/rc/twilio-v2.33.0-rc.2/twilio-v2.33.0-rc.2.tar.gz"
+  url "https://github.com/twilio/twilio-cli/releases/download/2.33.0-rc.2/twilio-2.33.0-rc.2.tar.gz"
   version "2.33.0-rc.2"
   sha256 "bb8252cca1cce30051da332fc46141938c6339b14d9e1d3164669a68854e72d3"
   depends_on "node"


### PR DESCRIPTION
<!-- Describe your Pull Request -->
# Fixes [DII-694](https://issues.corp.twilio.com/browse/DII-694)
The urls are modified to pickup artefacts from cli release assets instead of aws-s3 bucket.
For more context, refer [this PR](https://github.com/twilio/twilio-cli/pull/474).

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
