### PR TITLE
fix: corrected version patter

### DIFF
--- a/.github/scripts/update-formula.sh
+++ b/.github/scripts/update-formula.sh
@@ -1,4 +1,4 @@
-version_pattern="[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9])?"
+version_pattern="[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?"
 formula=$1
 version=$2
 sha=$3


### PR DESCRIPTION
<!-- Describe your Pull Request -->
I have corrected existing version pattern. It was not able to handle pattern such that 1.0.5-rc.11. Means version which has 2 or more digits after rc.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
