### PR TITLE
Use Node.js 18

### DIFF
--- a/Formula/twilio.rb
+++ b/Formula/twilio.rb
@@ -6,16 +6,17 @@ class Twilio < Formula
   url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v5.21.1/twilio-v5.21.1.tar.gz"
   version "5.21.1"
   sha256 "b3c553c3ce58fef5f216fda024795fb370aa2f613011d3b233edd25a5c005971"
-  depends_on "node"
+  depends_on "node@18"
 
   def install
     inreplace "bin/twilio", /^CLIENT_HOME=/, "export TWILIO_OCLIF_CLIENT_HOME=#{lib/"client"}\nCLIENT_HOME="
     libexec.install Dir["*"]
-    bin.install_symlink libexec/"bin/twilio"
+    (bin/"twilio").write_env_script libexec/"bin/twilio", PATH: "#{Formula["node@18"].opt_bin}:$PATH"
   end
 
   def post_install
-    pid = spawn("node #{libexec}/welcome.js")
+    node = Formula["node@18"].opt_bin/"node"
+    pid = spawn("#{node} #{libexec}/welcome.js")
     Process.wait pid
   end
 end


### PR DESCRIPTION
The installation docs state that the Twilio CLI only supports Node.js 18, and there are some minor compatability issues with Node.js 21, which is what the `node` formula currently resolves to.

See-also: twilio/twilio-cli#560

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
