### PR TITLE
Use node.js 20, as node.js 18 is unsupported

### DIFF
--- a/Formula/twilio.rb
+++ b/Formula/twilio.rb
@@ -6,16 +6,16 @@ class Twilio < Formula
   url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v6.1.0/twilio-v6.1.0.tar.gz"
   version "6.1.0"
   sha256 "0edd482872d1726ae8241a4b45fe5e175b46fe69418349b03a0474ff3e3243d8"
-  depends_on "node@18"
+  depends_on "node@20"
 
   def install
     inreplace "bin/twilio", /^CLIENT_HOME=/, "export TWILIO_OCLIF_CLIENT_HOME=#{lib/"client"}\nCLIENT_HOME="
     libexec.install Dir["*"]
-    (bin/"twilio").write_env_script libexec/"bin/twilio", PATH: "#{Formula["node@18"].opt_bin}:$PATH"
+    (bin/"twilio").write_env_script libexec/"bin/twilio", PATH: "#{Formula["node@20"].opt_bin}:$PATH"
   end
 
   def post_install
-    node = Formula["node@18"].opt_bin/"node"
+    node = Formula["node@20"].opt_bin/"node"
     pid = spawn("#{node} #{libexec}/welcome.js")
     Process.wait pid
   end


### PR DESCRIPTION
I noticed that the homebrew formula is currently set to depend on a node version the CLI no longer supports. This updates the dependency to the new minimum supported version.