### PR TITLE
Upgrade to node@24

### DIFF
--- a/Formula/twilio.rb
+++ b/Formula/twilio.rb
@@ -6,16 +6,16 @@ class Twilio < Formula
   url "https://twilio-cli-prod.s3.amazonaws.com/twilio-v6.2.4/twilio-v6.2.4.tar.gz"
   version "6.2.4"
   sha256 "fde2da58f02c400be405b4304bb7c5b53284b22428fe46fd86d0d24ff178d467"
-  depends_on "node@20"
+  depends_on "node@24"
 
   def install
     inreplace "bin/twilio", /^CLIENT_HOME=/, "export TWILIO_OCLIF_CLIENT_HOME=#{lib/"client"}\nCLIENT_HOME="
     libexec.install Dir["*"]
-    (bin/"twilio").write_env_script libexec/"bin/twilio", PATH: "#{Formula["node@20"].opt_bin}:$PATH"
+    (bin/"twilio").write_env_script libexec/"bin/twilio", PATH: "#{Formula["node@24"].opt_bin}:$PATH"
   end
 
   def post_install
-    node = Formula["node@20"].opt_bin/"node"
+    node = Formula["node@24"].opt_bin/"node"
     pid = spawn("#{node} #{libexec}/welcome.js")
     Process.wait pid
   end


### PR DESCRIPTION
node@20 is deprecated and brew emits a removal notice when installing. Updated formula to depend on node@24 and verified that twilio-cli installs and runs as expected.

Fixes #39 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
